### PR TITLE
allow matchedfilter alternative intval in getPeaklist

### DIFF
--- a/R/xsAnnotate.R
+++ b/R/xsAnnotate.R
@@ -1262,7 +1262,7 @@ getpspectra <- function(object, grp=NULL){
 setGeneric("getPeaklist", function(object, intval="into") standardGeneric("getPeaklist"))
 setMethod("getPeaklist", "xsAnnotate", function(object, intval="into") {
   
-  if (!sum(intval == c("into","intb","maxo"))){
+  if (!sum(intval == c("into","intb","maxo", "intf", "maxf"))){
        stop("unknown intensity value!")
   }
 


### PR DESCRIPTION
getPeaklist in CAMERA only allows the centwave intensity values of maxo, into and intb. matchedfilter uses different column names.
So this patch allowed retrieving those too.