### PR TITLE
Provide option to select intval in findAdducts function within xsAnnotate.R script

### DIFF
--- a/R/xsAnnotate.R
+++ b/R/xsAnnotate.R
@@ -763,10 +763,10 @@ setMethod("findIsotopes", "xsAnnotate",
   return(object);
 })
 
-setGeneric("findAdducts", function(object, ppm=5, mzabs=0.015, multiplier=3, polarity=NULL, 
+setGeneric("findAdducts", function(object, ppm=5, mzabs=0.015, multiplier=3, polarity=NULL, intval="maxo",
                                    rules=NULL, max_peaks=100, psg_list=NULL) standardGeneric("findAdducts"));
 setMethod("findAdducts", "xsAnnotate", function(object, ppm=5, mzabs=0.015, multiplier=3, polarity=NULL, 
-                                                rules=NULL, max_peaks=100, psg_list=NULL){
+                                                intval="maxo", rules=NULL, max_peaks=100, psg_list=NULL){
   multFragments=FALSE;
   # Scaling ppm factor
   devppm <- ppm / 1000000;
@@ -775,8 +775,6 @@ setMethod("findAdducts", "xsAnnotate", function(object, ppm=5, mzabs=0.015, mult
 
   # get mz values from peaklist
   imz    <- object@groupInfo[, "mz"];
-  #TODO: Change intensity choosing?
-  intval <- "maxo"; #max. intensity
 
   #number of pseudo-spectra
   npspectra <- length(object@pspectra);

--- a/man/findAdducts-methods.Rd
+++ b/man/findAdducts-methods.Rd
@@ -8,7 +8,7 @@
 }
 \usage{
  findAdducts(object, ppm=5, mzabs=0.015, multiplier=3, 
- polarity=NULL, rules=NULL, max_peaks=100, psg_list=NULL)
+ polarity=NULL, intval="maxo", rules=NULL, max_peaks=100, psg_list=NULL)
 }
 
 \arguments{
@@ -17,6 +17,7 @@
   \item{mzabs}{allowed variance for the search}
   \item{multiplier}{highest number(n) of allowed clusterion [nM+ion] }
   \item{polarity}{Which polarity mode was used for measuring of the ms sample}
+  \item{intval}{choose intensity values. Allowed values are into, maxo, intb }  
   \item{rules}{personal ruleset or with NULL standard ruleset will be calculated}
   \item{max_peaks}{If run in parralel mode, this number defines how much peaks will be calculated in every thread }
   \item{psg_list}{Vector of pseudospectra indices. The correlation analysis will be only done for those groups}


### PR DESCRIPTION
This commit is linked to issue #39, setting intval to "maxo" as default.