### PR TITLE
calcIso flag is transmited to groupCorr sub-function in annotateDiffreport function

### DIFF
--- a/R/xsAnnotate.R
+++ b/R/xsAnnotate.R
@@ -492,10 +492,12 @@ setMethod("groupCorr","xsAnnotate", function(object, cor_eic_th=0.75, pval=0.05,
   }
   
   #If object has isotope information and calcIso was selected
-  if( nrow(object@isoID) > 0 && calcIso){
-    res[[length(res)+1]] <- calcIsotopes(object);
-  }else if(nrow(object@isoID) == 0 && calcIso){
-    cat("Object contains no isotope or isotope annotation!\n");
+  if (calcIso) {
+    if (nrow(object@isoID) > 0) {
+      res[[length(res)+1]] <- calcIsotopes(object);
+    } else {
+      cat("Object contains no isotope or isotope annotation!\n");
+    }
   }
 
   #Check if we have at least 2 result matrixes
@@ -1159,7 +1161,7 @@ annotateDiffreport <- function(object, sample=NA, nSlaves=1, sigma=6, perfwhm=0.
     
     #Include into psg_list all groups that has been created after groupCorr
     cnt <- length(xa@pspectra);
-    xa <- groupCorr(xa,cor_eic_th=cor_eic_th,cor_exp_th=cor_exp_th,psg_list=psg_list)
+    xa <- groupCorr(xa,cor_eic_th=cor_eic_th,cor_exp_th=cor_exp_th,calcIso=calcIso,psg_list=psg_list)
     if(!is.null(psg_list)){
       psg_list <- c(psg_list,(cnt+1):length(xa@pspectra));
     }

--- a/inst/unitTests/test_annotateDiffreport.R
+++ b/inst/unitTests/test_annotateDiffreport.R
@@ -1,0 +1,17 @@
+
+test.annotateDiffreport.calcIso <- function() {
+
+  library(faahKO)
+
+  xs.group <- group(faahko)
+  xs.fill <- fillPeaks(xs.group)
+
+  calcIsoFALSE <- annotateDiffreport(xs.fill, calcIso = FALSE, calcCiS = TRUE, calcCaS = FALSE)
+  calcIsoTRUE  <- annotateDiffreport(xs.fill, calcIso = TRUE,  calcCiS = TRUE, calcCaS = FALSE)
+
+  checkTrue(
+    !identical(calcIsoTRUE[,"pcgroup"], calcIsoFALSE[,"pcgroup"]),
+    "The iso was not successfully computed with calcIso = TRUE flag."
+  )
+
+}


### PR DESCRIPTION
The calcIso flag was not properly transmitted from the function `annotateDiffreport` to the sub function `groupCorr` .

Flag is now transmitted and a unit test has been added to verify the pcgroups are impacted by the flag as these should be.

Fixes #65