### PR TITLE
[WIP - waiting for !66 ]Transmit annotate diffreport params to group corr

### DIFF
--- a/R/xsAnnotate.R
+++ b/R/xsAnnotate.R
@@ -1161,7 +1161,13 @@ annotateDiffreport <- function(object, sample=NA, nSlaves=1, sigma=6, perfwhm=0.
     
     #Include into psg_list all groups that has been created after groupCorr
     cnt <- length(xa@pspectra);
-    xa <- groupCorr(xa,cor_eic_th=cor_eic_th,cor_exp_th=cor_exp_th,calcIso=calcIso,psg_list=psg_list)
+    xa <- groupCorr(
+      xa,
+      cor_eic_th=cor_eic_th, cor_exp_th=cor_exp_th, calcIso=calcIso, psg_list=psg_list,
+      pval=pval, graphMethod=graphMethod, calcCiS=calcCiS, calcCaS=calcCaS, intval=intval
+    )
+    
+
     if(!is.null(psg_list)){
       psg_list <- c(psg_list,(cnt+1):length(xa@pspectra));
     }

--- a/R/xsAnnotate.R
+++ b/R/xsAnnotate.R
@@ -492,10 +492,12 @@ setMethod("groupCorr","xsAnnotate", function(object, cor_eic_th=0.75, pval=0.05,
   }
   
   #If object has isotope information and calcIso was selected
-  if( nrow(object@isoID) > 0 && calcIso){
-    res[[length(res)+1]] <- calcIsotopes(object);
-  }else if(nrow(object@isoID) == 0 && calcIso){
-    cat("Object contains no isotope or isotope annotation!\n");
+  if (calcIso) {
+    if (nrow(object@isoID) > 0) {
+      res[[length(res)+1]] <- calcIsotopes(object);
+    } else {
+      cat("Object contains no isotope or isotope annotation!\n");
+    }
   }
 
   #Check if we have at least 2 result matrixes
@@ -1159,7 +1161,7 @@ annotateDiffreport <- function(object, sample=NA, nSlaves=1, sigma=6, perfwhm=0.
     
     #Include into psg_list all groups that has been created after groupCorr
     cnt <- length(xa@pspectra);
-    xa <- groupCorr(xa,cor_eic_th=cor_eic_th,cor_exp_th=cor_exp_th,psg_list=psg_list)
+    xa <- groupCorr(xa,cor_eic_th=cor_eic_th,cor_exp_th=cor_exp_th,calcIso=calcIso,psg_list=psg_list)
     if(!is.null(psg_list)){
       psg_list <- c(psg_list,(cnt+1):length(xa@pspectra));
     }

--- a/inst/unitTests/test_annotateDiffreport.R
+++ b/inst/unitTests/test_annotateDiffreport.R
@@ -1,0 +1,17 @@
+
+test.annotateDiffreport.calcIso <- function() {
+
+  library(faahKO)
+
+  xs.group <- group(faahko)
+  xs.fill <- fillPeaks(xs.group)
+
+  calcIsoFALSE <- annotateDiffreport(xs.fill, calcIso = FALSE, calcCiS = TRUE, calcCaS = FALSE)
+  calcIsoTRUE  <- annotateDiffreport(xs.fill, calcIso = TRUE,  calcCiS = TRUE, calcCaS = FALSE)
+
+  checkTrue(
+    !identical(calcIsoTRUE[,"pcgroup"], calcIsoFALSE[,"pcgroup"]),
+    "The iso was not successfully computed with calcIso = TRUE flag."
+  )
+
+}

--- a/inst/unitTests/test_annotateDiffreport.R
+++ b/inst/unitTests/test_annotateDiffreport.R
@@ -1,17 +1,110 @@
 
+
+library(faahKO)
+
+test_data.xs.fill <- fillPeaks(group(faahko))
+
+
 test.annotateDiffreport.calcIso <- function() {
 
-  library(faahKO)
-
-  xs.group <- group(faahko)
-  xs.fill <- fillPeaks(xs.group)
-
-  calcIsoFALSE <- annotateDiffreport(xs.fill, calcIso = FALSE, calcCiS = TRUE, calcCaS = FALSE)
-  calcIsoTRUE  <- annotateDiffreport(xs.fill, calcIso = TRUE,  calcCiS = TRUE, calcCaS = FALSE)
+  calcIsoFALSE <- annotateDiffreport(test_data.xs.fill, calcIso=FALSE, calcCiS=TRUE, calcCaS=FALSE)
+  calcIsoTRUE  <- annotateDiffreport(test_data.xs.fill, calcIso=TRUE,  calcCiS=TRUE, calcCaS=FALSE)
 
   checkTrue(
     !identical(calcIsoTRUE[,"pcgroup"], calcIsoFALSE[,"pcgroup"]),
-    "The iso was not successfully computed with calcIso = TRUE flag."
+    "The iso was not successfully computed with calcIso=TRUE flag."
+  )
+}
+
+test.annotateDiffreport.pval <- function() {
+
+  checkException(annotateDiffreport(test_data.xs.fill, pval=-0.5))
+  checkException(annotateDiffreport(test_data.xs.fill, pval=1.5))
+
+  ## test that pval = 0 works
+  checkTrue(
+    nrow(annotateDiffreport(test_data.xs.fill, pval=0)) != 0,
+    "annotateDiffreport with pval=0 failed."
+  )
+  ## test that pval = 1 works
+  checkTrue(
+    nrow(annotateDiffreport(test_data.xs.fill, pval=1)) != 0,
+    "annotateDiffreport with pval=1 failed."
+  )
+
+  lower <- 0
+  upper <- 0.6
+  middle <- 0.1
+
+  lower_result <- annotateDiffreport(test_data.xs.fill, pval=lower)
+  middle_result <- annotateDiffreport(test_data.xs.fill, pval=middle)
+  upper_result  <- annotateDiffreport(test_data.xs.fill, pval=upper)
+
+  checkTrue(
+    !identical(upper_result[,"pcgroup"], lower_result[,"pcgroup"]),
+    paste0("Got the same results with pval = ", upper, " and pval = ", lower, " .")
+  )
+
+  checkTrue(
+    !identical(middle_result, upper_result),
+    paste0("Got the same results with pval = ", middle, " and pval = ", upper, " .")
+  )
+
+  checkTrue(
+    !identical(middle_result[,"pcgroup"], lower_result[,"pcgroup"]),
+    paste0("Got the same results with pval = ", middle, " and pval = ", lower, " .")
+  )
+
+}
+
+test.annotateDiffreport.graphMethod <- function() {
+
+  graphMethod_hcs <- annotateDiffreport(test_data.xs.fill, graphMethod="hcs")
+  graphMethod_lpc  <- annotateDiffreport(test_data.xs.fill, graphMethod="lpc")
+
+  checkTrue(
+    !identical(graphMethod_lpc[,"pcgroup"], graphMethod_hcs[,"pcgroup"]),
+    "Got the same results with graphMethod = hcp and graphMethod = lcp."
+  )
+
+}
+
+test.annotateDiffreport.calcCiS <- function() {
+
+  checkException(annotateDiffreport(test_data.xs.fill, calcCiS=FALSE))
+
+  calcCiSFALSE <- annotateDiffreport(test_data.xs.fill, calcCiS=FALSE, calcCaS=TRUE)
+  calcCiSTRUE  <- annotateDiffreport(test_data.xs.fill, calcCiS=TRUE)
+
+  checkTrue(
+    !identical(calcCiSTRUE[,"pcgroup"], calcCiSFALSE[,"pcgroup"]),
+    "Got the same results with calcCis = true and calcCis = false."
+  )
+
+}
+
+test.annotateDiffreport.calcCaS <- function() {
+
+  checkException(annotateDiffreport(test_data.xs.fill, calcCaS=FALSE, calcCis=FALSE))
+
+  calcCaSFALSE <- annotateDiffreport(test_data.xs.fill, calcCaS=FALSE, calcCiS=TRUE)
+  calcCaSTRUE  <- annotateDiffreport(test_data.xs.fill, calcCaS=TRUE)
+
+  checkTrue(
+    !identical(calcCaSTRUE[,"pcgroup"], calcCaSFALSE[,"pcgroup"]),
+    "Got the same results with calcCas = true and calcCas = false"
+  )
+
+}
+
+test.annotateDiffreport.intval <- function() {
+
+  intval_into <- annotateDiffreport(test_data.xs.fill, intval="into", calcCaS=TRUE)
+  intval_maxo  <- annotateDiffreport(test_data.xs.fill, intval="maxo", calcCaS=TRUE)
+
+  checkTrue(
+    !identical(intval_into, intval_maxo),
+    "Got the same results with intVal = into and intVal = maxo."
   )
 
 }


### PR DESCRIPTION
Some parameters taken by annotateDiffreport were not properly transmitted to groupCorr.
The following parameters are now transmitted, and unit tests related to theses parameters have been created:
 - pval ;
 - graphMethod ;
 - calcCiS ;
 - calcCaS ;
 - intval.


Fixes #67 .